### PR TITLE
fix active menu/nav item highlight

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,11 +11,18 @@
       {% for nav in navButtons %}
         {% assign navURL = nav %}
         {% assign pageURL = page.url %}
+        {% assign pageURLSplit = page.url | split: "/" %}
         {% if nav == "home" %}
           {% assign navURL = "" %}
         {% endif %}
         
-        {% if pageURL == navURL %}
+        {% if pageURLSplit[1] == navURL %}
+          <li class="{{ nav }}-button">
+            <a class="active" href="{{ site.baseurl }}/{{ navURL }}">
+            <span class="nav-text">{{ nav | upcase }}</span></a>
+          </li>
+
+        {% elsif navURL == "" and pageURL == "/" %}
           <li class="{{ nav }}-button">
             <a class="active" href="{{ site.baseurl }}/{{ navURL }}">
             <span class="nav-text">{{ nav | upcase }}</span></a>


### PR DESCRIPTION
The code had some broken logic on detecting the currently "active" page. I fixed the functionality. It also works for nested pages based on the top-level nav commands. For example, a personal page (like Alex's) starts with `team/'` in the URL scheme, so "Team" is highlighted. Works similarly for publication pages.

This does mean hover effects of the menu show two things. Considering that most devices use a mouse or trackpad for hover effects, the user is more likely to track their cursor and know which item they are looking to click. Could be wrong, so feel free to write an issue on that. Not sure how else to fix that without some javascript to change the "active" class to something temporarily, on a menu item hover.