### PR TITLE
add more content to text citation on pub page

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -67,7 +67,9 @@ layout: default
             {% assign published-where = page.bib.publisher %}
           {% endif %}
 
-          {{ published-where }}, {% if page.bib.doi %} <a href="http://dx.doi.org/{{ page.bib.doi }}">doi:{{ page.bib.doi }}</a>, {%endif%}{{ page.year }}.
+
+
+          {{ published-where }}, {% if page.bib.volume %} {{ page.bib.volume }}{% endif %}{% if page.bib.number %}({{ page.bib.number }}){% endif %}{% if page.bib.volume or page.bib.issue %}:{% endif %}{% if page.bib.pages %} {{ page.bib.pages }}, {% endif %} {% if page.bib.doi %} <a href="http://dx.doi.org/{{ page.bib.doi }}">doi:{{ page.bib.doi }}</a>, {%endif%}{{ page.year }}.
         {% endif %}
         </span>
 


### PR DESCRIPTION
Per Alex's request, added some Liquid syntax to render the volume, issue numbers, and pages from our bib content for each pub. Tries to only fill in when appropriate, so may be sufficient.

In the future, another possible alternative is to write some JS that takes our bibtex we generate and parses it, in case there are issues with the implementation here. If you need this in the future, I would suggest checking out: https://github.com/pcooksey/bibtex-js